### PR TITLE
STUDIO-52_updated the dokku deploy steps accordingly

### DIFF
--- a/post-deploy
+++ b/post-deploy
@@ -6,14 +6,14 @@ APP="$1"; IMAGE="dokku/$APP"
 echo "-----> Installing clamav ..."
 COMMAND=$(cat <<EOF
 echo "-----> start daemon!"
-clamd &
+sudo clamd &
 echo "-----> end daemon!"
 sleep 1 # wait so that docker run has not exited before docker attach
 EOF
 )
 
 # /etc/init.d/clamav-daemon start
-id=$(docker run -d $IMAGE /bin/bash -e -c "$COMMAND")
+id=$(docker run -d $IMAGE /bin/bash -e -c "$COMMAND" --expose 3310)
 #enable logs
 docker attach $id
 test $(docker wait $id) -eq 0

--- a/post-deploy
+++ b/post-deploy
@@ -13,8 +13,8 @@ EOF
 )
 
 # /etc/init.d/clamav-daemon start
-id=$(docker run -d $IMAGE /bin/bash -e -c "$COMMAND")
-#enable logs
-docker attach $id
-test $(docker wait $id) -eq 0
-docker commit $id $IMAGE > /dev/null
+# id=$(docker run -d $IMAGE /bin/bash -e -c "$COMMAND")
+# #enable logs
+# docker attach $id
+# test $(docker wait $id) -eq 0
+# docker commit $id $IMAGE > /dev/null

--- a/post-deploy
+++ b/post-deploy
@@ -3,10 +3,11 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 APP="$1"; IMAGE="dokku/$APP"
-echo "-----> Installing clamav ..."
+echo "-----> Running post deploy"
 COMMAND=$(cat <<EOF
 echo "-----> start daemon!"
-clamd &
+freshclam -d &
+clamd
 echo "-----> end daemon!"
 sleep 1 # wait so that docker run has not exited before docker attach
 EOF

--- a/post-deploy
+++ b/post-deploy
@@ -2,19 +2,19 @@
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
-# APP="$1"; IMAGE="dokku/$APP"
-# echo "-----> Installing clamav ..."
-# COMMAND=$(cat <<EOF
-# echo "-----> start daemon!"
-# /etc/init.d/clamav-daemon start
-# echo "-----> end daemon!"
-# sleep 1 # wait so that docker run has not exited before docker attach
-# EOF
-# )
-
+APP="$1"; IMAGE="dokku/$APP"
+echo "-----> Installing clamav ..."
+COMMAND=$(cat <<EOF
+echo "-----> start daemon!"
 /etc/init.d/clamav-daemon start
-# id=$(docker run -d $IMAGE /bin/bash -e -c "$COMMAND")
-# #enable logs
-# docker attach $id
-# test $(docker wait $id) -eq 0
-# docker commit $id $IMAGE > /dev/null
+echo "-----> end daemon!"
+sleep 1 # wait so that docker run has not exited before docker attach
+EOF
+)
+
+# /etc/init.d/clamav-daemon start
+id=$(docker run -d $IMAGE /bin/bash -e -c "$COMMAND")
+#enable logs
+docker attach $id
+test $(docker wait $id) -eq 0
+docker commit $id $IMAGE > /dev/null

--- a/post-deploy
+++ b/post-deploy
@@ -5,10 +5,6 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 APP="$1"; IMAGE="dokku/$APP"
 echo "-----> Running post deploy"
 COMMAND=$(cat <<EOF
-echo "-----> start daemon!"
-freshclam -d &
-clamd &
-echo "-----> end daemon!"
 sleep 1 # wait so that docker run has not exited before docker attach
 EOF
 )

--- a/post-deploy
+++ b/post-deploy
@@ -7,7 +7,7 @@ echo "-----> Running post deploy"
 COMMAND=$(cat <<EOF
 echo "-----> start daemon!"
 freshclam -d &
-clamd
+clamd &
 echo "-----> end daemon!"
 sleep 1 # wait so that docker run has not exited before docker attach
 EOF

--- a/post-deploy
+++ b/post-deploy
@@ -13,7 +13,7 @@ EOF
 )
 
 # /etc/init.d/clamav-daemon start
-id=$(docker run -d $IMAGE /bin/bash -e -c "$COMMAND" --expose 3310)
+id=$(docker run -d $IMAGE /bin/bash -e -c "$COMMAND")
 #enable logs
 docker attach $id
 test $(docker wait $id) -eq 0

--- a/post-deploy
+++ b/post-deploy
@@ -6,7 +6,7 @@ APP="$1"; IMAGE="dokku/$APP"
 echo "-----> Installing clamav ..."
 COMMAND=$(cat <<EOF
 echo "-----> start daemon!"
-sudo clamd &
+clamd &
 echo "-----> end daemon!"
 sleep 1 # wait so that docker run has not exited before docker attach
 EOF

--- a/post-deploy
+++ b/post-deploy
@@ -6,7 +6,7 @@ APP="$1"; IMAGE="dokku/$APP"
 echo "-----> Installing clamav ..."
 COMMAND=$(cat <<EOF
 echo "-----> start daemon!"
-/etc/init.d/clamav-daemon start
+clamd &
 echo "-----> end daemon!"
 sleep 1 # wait so that docker run has not exited before docker attach
 EOF

--- a/post-deploy
+++ b/post-deploy
@@ -13,8 +13,8 @@ EOF
 )
 
 # /etc/init.d/clamav-daemon start
-# id=$(docker run -d $IMAGE /bin/bash -e -c "$COMMAND")
-# #enable logs
-# docker attach $id
-# test $(docker wait $id) -eq 0
-# docker commit $id $IMAGE > /dev/null
+id=$(docker run -d $IMAGE /bin/bash -e -c "$COMMAND")
+#enable logs
+docker attach $id
+test $(docker wait $id) -eq 0
+docker commit $id $IMAGE > /dev/null

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -7,6 +7,11 @@ echo ID
 echo "-----> Installing clamav ..."
 COMMAND=$(cat <<EOF
 echo "-----> install requirements"
+echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-free" > /etc/apt/sources.list && \
+    echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION-updates main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://security.debian.org/ $DEBIAN_VERSION/updates main contrib non-free" >> /etc/apt/sources.list
+apt-get -y update
+
 apt-get install -y clamav clamav-daemon
 
 echo "-----> Update database"

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -8,25 +8,18 @@ echo "-----> install requirements"
 
 apt-add-repository multiverse
 apt-get -y update
-apt-get install --no-install-recommends -y -qq clamav-daemon clamav-freshclam libclamunrar9 wget
+apt-get install -y clamav clamav-daemon clamav-freshclam libclamunrar9 wget
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 
 echo "-----> update database"
-wget -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd
-wget -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd
-wget -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd
-chown clamav:clamav /var/lib/clamav/*.cvd
+freshclam
 echo "-----> Setting permissions"
 mkdir /var/run/clamav
-chown clamav:clamav /var/run/clamav
-chmod 750 /var/run/clamav
+apt-add-repository multiverse
 sleep 1 # wait so that docker run has not exited before docker attach
-sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf
-echo "TCPSocket 3310" >> /etc/clamav/clamd.conf
-if ! [ -z $HTTPProxyServer ]; then echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf; fi
-if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi
-sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
+
+clamav
 EOF
 )
 id=$(docker run -d $IMAGE /bin/bash -e -c "$COMMAND")

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -8,32 +8,27 @@ echo "-----> install requirements"
 
 add-apt-repository multiverse
 apt-get -y update
-apt-get install --no-install-recommends -y -qq clamav clamav-daemon clamav-freshclam libclamunrar9 ca-certificates netcat-openbsd
-apt-get clean
-rm -rf /var/lib/apt/lists/*
+apt-get install -y clamav
 
 echo "-----> update database"
-wget -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd
-wget -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd
-wget -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd
-chown clamav:clamav /var/lib/clamav/*.cvd
+touch /usr/local/etc/clamav/freshclam.conf
+touch /usr/local/etc/clamav/clamd.conf
+
+echo "DatabaseMirror database.clamav.net" >> /usr/local/etc/clamav/freshclam.conf
+echo "LocalSocket /usr/local/var/run/clamav/clamd.sock" >> /usr/local/etc/clamav/clamd.conf
+
+freshclam -v
 
 echo "-----> Setting permissions"
-mkdir /var/run/clamav
-chown clamav:clamav /var/run/clamav
-chmod 750 /var/run/clamav
+chown clamav /usr/local/var/run/clamav/
+chmod 775 /usr/local/var/run/clamav/
+export PATH=/usr/local/sbin:$PATH
+
 sleep 1 # wait so that docker run has not exited before docker attach
 
-sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf
-sed 's/LocalSocketGroup clamav/LocalSocketGroup root/g' /etc/clamav/clamd.conf
-sed 's/User clamav/User root/g' /etc/clamav/clamd.conf
-echo "TCPSocket 3310" >> /etc/clamav/clamd.conf
-if ! [ -z $HTTPProxyServer ]; then echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf; fi
-if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi
-sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
 EOF
 )
-id=$(docker run --expose 3310 -d $IMAGE /bin/bash -e -c "$COMMAND")
+id=$(docker run -d $IMAGE /bin/bash -e -c "$COMMAND")
 #enable logs
 docker attach $id
 test $(docker wait $id) -eq 0

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -7,28 +7,28 @@ echo ID
 echo "-----> Installing clamav ..."
 COMMAND=$(cat <<EOF
 echo "-----> install requirements"
-
 apt-get install -y clamav clamav-daemon
 
-mkdir /usr/local/etc/clamav
+echo "-----> Update database"
+wget -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd && \
+    wget -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd && \
+    wget -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd && \
+    chown clamav:clamav /var/lib/clamav/*.cvd
 
-# clamdscan is needed for the gem to get the clamav scanner
-mkdir /usr/bin/clamdscan
-chown clamav /usr/bin/clamdscan
-chmod 775 /usr/bin/clamdscan
+echo "-----> Set permissions"
+mkdir /var/run/clamav && \
+    chown clamav:clamav /var/run/clamav && \
+    chmod 777 /var/run/clamav
 
-# Configure clamav daemon and updater
-touch /usr/local/etc/clamav/freshclam.conf
-touch /usr/local/etc/clamav/clamd.conf
-
-cd /usr/local/etc/clamav
-echo "-----> update database"
-echo "DatabaseMirror database.clamav.net" >> freshclam.conf 
-freshclam -v # Run updater
-
-echo "LocalSocket /usr/local/var/run/clamav/clamd.sock" >> clamd.conf
-
-clamd & # Start daemon
+echo "-----> Update configuration"
+sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
+    echo "TCPSocket 3310" >> /etc/clamav/clamd.conf && \
+    if ! [ -z $HTTPProxyServer ]; then echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf; fi && \
+    if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi && \
+    sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.
+    
+echo "-----> Run clamav daemon"
+clamd &
 
 sleep 1 # wait so that docker run has not exited before docker attach
 

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -8,18 +8,25 @@ echo "-----> install requirements"
 
 apt-get install -y clamav clamav-daemon
 
-echo "-----> update database"
 mkdir /usr/local/etc/clamav
+
+# clamdscan is needed for the gem to get the clamav scanner
+mkdir /usr/bin/clamdscan
+chown clamav /usr/bin/clamdscan
+chmod 775 /usr/bin/clamdscan
+
+# Configure clamav daemon and updater
 touch /usr/local/etc/clamav/freshclam.conf
 touch /usr/local/etc/clamav/clamd.conf
 
 cd /usr/local/etc/clamav
+echo "-----> update database"
 echo "DatabaseMirror database.clamav.net" >> freshclam.conf 
-freshclam -v
+freshclam -v # Run updater
 
 echo "LocalSocket /usr/local/var/run/clamav/clamd.sock" >> clamd.conf
 
-clamd &
+clamd & # Start daemon
 
 sleep 1 # wait so that docker run has not exited before docker attach
 

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -7,9 +7,7 @@ echo ID
 echo "-----> Installing clamav ..."
 COMMAND=$(cat <<EOF
 echo "-----> install requirements"
-echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-free" > /etc/apt/sources.list && \
-    echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION-updates main contrib non-free" >> /etc/apt/sources.list && \
-    echo "deb http://security.debian.org/ $DEBIAN_VERSION/updates main contrib non-free" >> /etc/apt/sources.list
+apt-add-repository multiverse
 apt-get -y update
 
 apt-get install -y clamav clamav-daemon

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -9,6 +9,8 @@ echo "-----> install requirements"
 add-apt-repository multiverse
 apt-get -y update
 apt-get install -y clamav clamav-daemon clamd clamav-freshclam libclamunrar9
+apt-get clean
+rm -rf /var/lib/apt/lists/*
 
 echo "-----> update database"
 freshclam
@@ -16,13 +18,20 @@ echo "-----> Setting permissions"
 mkdir /var/run/clamav
 touch /var/run/clamav/clamd.sock
 touch /var/run/clamav/clamd.ctl
+chown clamav:clamav /var/run/clamav
+chmod 750 /var/run/clamav
 sleep 1 # wait so that docker run has not exited before docker attach
 
-clamd
+sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf
+echo "TCPSocket 3310" >> /etc/clamav/clamd.conf
+if ! [ -z $HTTPProxyServer ]; then echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf; fi
+if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi
+sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
+
 clamav
 EOF
 )
-id=$(docker run -d $IMAGE /bin/bash -e -c "$COMMAND")
+id=$(docker run -d $IMAGE /bin/bash -e -c "$COMMAND" --expose 3310)
 #enable logs
 docker attach $id
 test $(docker wait $id) -eq 0

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -8,7 +8,7 @@ echo "-----> install requirements"
 
 add-apt-repository multiverse
 apt-get -y update
-apt-get install -y clamav clamav-daemon clamav-freshclam libclamunrar9 wget
+apt-get install -y clamav clamav-daemon clamd clamav-freshclam libclamunrar9
 
 echo "-----> update database"
 freshclam
@@ -18,6 +18,7 @@ touch /var/run/clamav/clamd.sock
 touch /var/run/clamav/clamd.ctl
 sleep 1 # wait so that docker run has not exited before docker attach
 
+clamd
 clamav
 EOF
 )

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -9,8 +9,6 @@ echo "-----> install requirements"
 apt-add-repository multiverse
 apt-get -y update
 apt-get install -y clamav clamav-daemon clamav-freshclam libclamunrar9 wget
-apt-get clean
-rm -rf /var/lib/apt/lists/*
 
 echo "-----> update database"
 freshclam

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -19,8 +19,6 @@ echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-free" 
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-apt-get install -y clamav clamav-daemon
-
 echo "-----> Update database"
 wget -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd && \
     wget -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd && \

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -7,8 +7,17 @@ echo ID
 echo "-----> Installing clamav ..."
 COMMAND=$(cat <<EOF
 echo "-----> install requirements"
-apt-add-repository multiverse
-apt-get -y update
+echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-free" > /etc/apt/sources.list && \
+    echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION-updates main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://security.debian.org/ $DEBIAN_VERSION/updates main contrib non-free" >> /etc/apt/sources.list && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y -qq \
+        clamav-daemon \
+        clamav-freshclam \
+        libclamunrar9 \
+        wget && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 apt-get install -y clamav clamav-daemon
 

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -33,6 +33,13 @@ sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
 
 clamd &
 
+if [ "$(echo PING | nc localhost 3310)" = "PONG" ]; then
+    echo "ping successful"
+else
+    echo 1>&2 "ping failed"
+    sleep 30
+fi
+
 sleep 1 # wait so that docker run has not exited before docker attach
 
 EOF

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -7,9 +7,7 @@ echo ID
 echo "-----> Installing clamav ..."
 COMMAND=$(cat <<EOF
 echo "-----> install requirements"
-# echo "deb http://archive.ubuntu.com trusty main universe multiverse" > /etc/apt/sources.list && \
-#     echo "deb http://archive.ubuntu.com trusty-updates main universe multiverse" >> /etc/apt/sources.list && \
-#     echo "deb http://archive.ubuntu.com trusty-security main universe multiverse" >> /etc/apt/sources.list
+apt-get update
 apt-get install -y software-properties-common
 apt-get update
 add-apt-repository multiverse

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -16,7 +16,8 @@ echo "-----> update database"
 freshclam
 echo "-----> Setting permissions"
 mkdir /var/run/clamav
-apt-add-repository multiverse
+touch /var/run/clamav/clamd.sock
+touch /var/run/clamav/clamd.ctl
 sleep 1 # wait so that docker run has not exited before docker attach
 
 clamav

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -30,9 +30,6 @@ sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     if ! [ -z $HTTPProxyServer ]; then echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf; fi && \
     if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi && \
     sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
-    
-echo "-----> Run clamav daemon"
-clamd &
 
 sleep 1 # wait so that docker run has not exited before docker attach
 

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -6,7 +6,7 @@ echo "-----> Installing clamav ..."
 COMMAND=$(cat <<EOF
 echo "-----> install requirements"
 
-apt-add-repository multiverse
+add-apt-repository multiverse
 apt-get -y update
 apt-get install -y clamav clamav-daemon clamav-freshclam libclamunrar9 wget
 

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -15,7 +15,7 @@ rm -rf /var/lib/apt/lists/*
 echo "-----> update database"
 systemctl stop clamav-daemon.service
 rm /var/log/clamav/freshclam.log
-systemctl start clamav-daemon.service
+systemctl start clamav-daemon
 freshclam
 echo "-----> Setting permissions"
 mkdir /var/run/clamav
@@ -26,6 +26,8 @@ chmod 750 /var/run/clamav
 sleep 1 # wait so that docker run has not exited before docker attach
 
 sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf
+sed 's/LocalSocketGroup clamav/LocalSocketGroup root/g' /etc/clamav/clamd.conf
+sed 's/User clamav/User root/g' /etc/clamav/clamd.conf
 echo "TCPSocket 3310" >> /etc/clamav/clamd.conf
 if ! [ -z $HTTPProxyServer ]; then echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf; fi
 if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -7,10 +7,9 @@ echo ID
 echo "-----> Installing clamav ..."
 COMMAND=$(cat <<EOF
 echo "-----> install requirements"
-apt-get update
-echo "deb http://http.debian.net/debian/ trusty main contrib non-free" > /etc/apt/sources.list && \
-    echo "deb http://http.debian.net/debian/ trusty-updates main contrib non-free" >> /etc/apt/sources.list && \
-    echo "deb http://security.debian.org/ trusty/updates main contrib non-free" >> /etc/apt/sources.list
+echo "deb http://archive.ubuntu.com trusty main universe multiverse" > /etc/apt/sources.list && \
+    echo "deb http://archive.ubuntu.com trusty-updates main universe multiverse" >> /etc/apt/sources.list && \
+    echo "deb http://archive.ubuntu.com trusty-security main universe multiverse" >> /etc/apt/sources.list
 apt-get update
 apt-get install -y clamav clamav-daemon
 

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -6,23 +6,20 @@ echo "-----> Installing clamav ..."
 COMMAND=$(cat <<EOF
 echo "-----> install requirements"
 
-add-apt-repository multiverse
-apt-get -y update
-apt-get install -y clamav
+apt-get install -y clamav clamav-daemon
 
 echo "-----> update database"
+mkdir /usr/local/etc/clamav
 touch /usr/local/etc/clamav/freshclam.conf
 touch /usr/local/etc/clamav/clamd.conf
 
-echo "DatabaseMirror database.clamav.net" >> /usr/local/etc/clamav/freshclam.conf
-echo "LocalSocket /usr/local/var/run/clamav/clamd.sock" >> /usr/local/etc/clamav/clamd.conf
-
+cd /usr/local/etc/clamav
+echo "DatabaseMirror database.clamav.net" >> freshclam.conf 
 freshclam -v
 
-echo "-----> Setting permissions"
-chown clamav /usr/local/var/run/clamav/
-chmod 775 /usr/local/var/run/clamav/
-export PATH=/usr/local/sbin:$PATH
+echo "LocalSocket /usr/local/var/run/clamav/clamd.sock" >> clamd.conf
+
+clamd &
 
 sleep 1 # wait so that docker run has not exited before docker attach
 

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -11,7 +11,8 @@ apt-get update
 apt-get install -y software-properties-common
 apt-get update
 add-apt-repository multiverse
-apt-get install -y clamav clamav-daemon
+apt-get install -y clamav clamav-daemon clamav-freshclam
+apt-get clean
 
 echo "-----> Update database"
 wget -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd && \

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -8,7 +8,7 @@ echo "-----> install requirements"
 
 add-apt-repository multiverse
 apt-get -y update
-apt-get install --no-install-recommends -y -qq clamav-daemon clamav-freshclam libclamunrar9 ca-certificates netcat-openbsd
+apt-get install --no-install-recommends -y -qq clamav clamav-daemon clamav-freshclam libclamunrar9 ca-certificates netcat-openbsd
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -8,9 +8,9 @@ echo "-----> Installing clamav ..."
 COMMAND=$(cat <<EOF
 echo "-----> install requirements"
 apt-get update
-echo "deb http://http.debian.net/debian/ stretch main contrib non-free" > /etc/apt/sources.list && \
-    echo "deb http://http.debian.net/debian/ stretch-updates main contrib non-free" >> /etc/apt/sources.list && \
-    echo "deb http://security.debian.org/ stretch/updates main contrib non-free" >> /etc/apt/sources.list
+echo "deb http://http.debian.net/debian/ trusty main contrib non-free" > /etc/apt/sources.list && \
+    echo "deb http://http.debian.net/debian/ trusty-updates main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://security.debian.org/ trusty/updates main contrib non-free" >> /etc/apt/sources.list
 apt-get update
 apt-get install -y clamav clamav-daemon
 

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -7,10 +7,12 @@ echo ID
 echo "-----> Installing clamav ..."
 COMMAND=$(cat <<EOF
 echo "-----> install requirements"
-echo "deb http://archive.ubuntu.com trusty main universe multiverse" > /etc/apt/sources.list && \
-    echo "deb http://archive.ubuntu.com trusty-updates main universe multiverse" >> /etc/apt/sources.list && \
-    echo "deb http://archive.ubuntu.com trusty-security main universe multiverse" >> /etc/apt/sources.list
+# echo "deb http://archive.ubuntu.com trusty main universe multiverse" > /etc/apt/sources.list && \
+#     echo "deb http://archive.ubuntu.com trusty-updates main universe multiverse" >> /etc/apt/sources.list && \
+#     echo "deb http://archive.ubuntu.com trusty-security main universe multiverse" >> /etc/apt/sources.list
+apt-get install -y software-properties-common
 apt-get update
+add-apt-repository multiverse
 apt-get install -y clamav clamav-daemon
 
 echo "-----> Update database"

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -31,15 +31,6 @@ sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi && \
     sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
 
-clamd &
-
-if [ "$(echo PING | nc localhost 3310)" = "PONG" ]; then
-    echo "ping successful"
-else
-    echo 1>&2 "ping failed"
-    sleep 30
-fi
-
 sleep 1 # wait so that docker run has not exited before docker attach
 
 EOF

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -7,15 +7,25 @@ COMMAND=$(cat <<EOF
 echo "-----> install requirements"
 
 apt-get -y update
-apt-get install -y clamav clamav-daemon
+apt-get install --no-install-recommends -y -qq clamav-daemon clamav-freshclam libclamunrar9 wget
+apt-get clean
+rm -rf /var/lib/apt/lists/*
 
 echo "-----> update database"
-freshclam
-echo "-----> create file clamd.sock"
+wget -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd
+wget -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd
+wget -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd
+chown clamav:clamav /var/lib/clamav/*.cvd
+echo "-----> Setting permissions"
 mkdir /var/run/clamav
-touch /var/run/clamav/clamd.sock
-touch /var/run/clamav/clamd.ctl
+chown clamav:clamav /var/run/clamav
+chmod 750 /var/run/clamav
 sleep 1 # wait so that docker run has not exited before docker attach
+sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf
+echo "TCPSocket 3310" >> /etc/clamav/clamd.conf
+if ! [ -z $HTTPProxyServer ]; then echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf; fi
+if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi
+sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
 EOF
 )
 id=$(docker run -d $IMAGE /bin/bash -e -c "$COMMAND")

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -13,6 +13,9 @@ apt-get clean
 rm -rf /var/lib/apt/lists/*
 
 echo "-----> update database"
+systemctl stop clamav-daemon.service
+rm /var/log/clamav/freshclam.log
+systemctl start clamav-daemon.service
 freshclam
 echo "-----> Setting permissions"
 mkdir /var/run/clamav

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -27,8 +27,6 @@ echo "TCPSocket 3310" >> /etc/clamav/clamd.conf
 if ! [ -z $HTTPProxyServer ]; then echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf; fi
 if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi
 sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
-
-clamav
 EOF
 )
 id=$(docker run -d $IMAGE /bin/bash -e -c "$COMMAND" --expose 3310)

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -8,19 +8,18 @@ echo "-----> install requirements"
 
 add-apt-repository multiverse
 apt-get -y update
-apt-get install -y clamav clamav-daemon clamd clamav-freshclam libclamunrar9
+apt-get install --no-install-recommends -y -qq clamav-daemon clamav-freshclam libclamunrar9 ca-certificates netcat-openbsd
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 
 echo "-----> update database"
-systemctl stop clamav-daemon.service
-rm /var/log/clamav/freshclam.log
-systemctl start clamav-daemon
-freshclam
+wget -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd
+wget -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd
+wget -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd
+chown clamav:clamav /var/lib/clamav/*.cvd
+
 echo "-----> Setting permissions"
 mkdir /var/run/clamav
-touch /var/run/clamav/clamd.sock
-touch /var/run/clamav/clamd.ctl
 chown clamav:clamav /var/run/clamav
 chmod 750 /var/run/clamav
 sleep 1 # wait so that docker run has not exited before docker attach
@@ -34,7 +33,7 @@ if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/c
 sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
 EOF
 )
-id=$(docker run -d $IMAGE /bin/bash -e -c "$COMMAND" --expose 3310)
+id=$(docker run --expose 3310 -d $IMAGE /bin/bash -e -c "$COMMAND")
 #enable logs
 docker attach $id
 test $(docker wait $id) -eq 0

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -11,8 +11,7 @@ apt-get update
 apt-get install -y software-properties-common
 apt-get update
 add-apt-repository multiverse
-apt-get install -y clamav clamav-daemon clamav-freshclam
-apt-get clean
+apt-get install -y clamav clamav-daemon
 
 echo "-----> Update database"
 wget -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd && \
@@ -30,7 +29,7 @@ sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     echo "TCPSocket 3310" >> /etc/clamav/clamd.conf && \
     if ! [ -z $HTTPProxyServer ]; then echo "HTTPProxyServer $HTTPProxyServer" >> /etc/clamav/freshclam.conf; fi && \
     if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi && \
-    sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.
+    sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
     
 echo "-----> Run clamav daemon"
 clamd &

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -7,17 +7,12 @@ echo ID
 echo "-----> Installing clamav ..."
 COMMAND=$(cat <<EOF
 echo "-----> install requirements"
+apt-get update
 echo "deb http://http.debian.net/debian/ stretch main contrib non-free" > /etc/apt/sources.list && \
     echo "deb http://http.debian.net/debian/ stretch-updates main contrib non-free" >> /etc/apt/sources.list && \
-    echo "deb http://security.debian.org/ stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y -qq \
-        clamav-daemon \
-        clamav-freshclam \
-        libclamunrar9 \
-        wget && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    echo "deb http://security.debian.org/ stretch/updates main contrib non-free" >> /etc/apt/sources.list
+apt-get update
+apt-get install -y clamav clamav-daemon
 
 echo "-----> Update database"
 wget -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd && \

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -7,9 +7,9 @@ echo ID
 echo "-----> Installing clamav ..."
 COMMAND=$(cat <<EOF
 echo "-----> install requirements"
-echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-free" > /etc/apt/sources.list && \
-    echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION-updates main contrib non-free" >> /etc/apt/sources.list && \
-    echo "deb http://security.debian.org/ $DEBIAN_VERSION/updates main contrib non-free" >> /etc/apt/sources.list && \
+echo "deb http://http.debian.net/debian/ stretch main contrib non-free" > /etc/apt/sources.list && \
+    echo "deb http://http.debian.net/debian/ stretch-updates main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://security.debian.org/ stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y -qq \
         clamav-daemon \

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -6,6 +6,7 @@ echo "-----> Installing clamav ..."
 COMMAND=$(cat <<EOF
 echo "-----> install requirements"
 
+apt-add-repository multiverse
 apt-get -y update
 apt-get install --no-install-recommends -y -qq clamav-daemon clamav-freshclam libclamunrar9 wget
 apt-get clean

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -31,6 +31,8 @@ sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     if ! [ -z $HTTPProxyPort   ]; then echo "HTTPProxyPort $HTTPProxyPort" >> /etc/clamav/freshclam.conf; fi && \
     sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
 
+clamd &
+
 sleep 1 # wait so that docker run has not exited before docker attach
 
 EOF

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -2,6 +2,8 @@
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 APP="$1"; IMAGE="dokku/$APP"
+echo APP
+echo ID
 echo "-----> Installing clamav ..."
 COMMAND=$(cat <<EOF
 echo "-----> install requirements"


### PR DESCRIPTION
### Purpose
Complete revamp of dokku build steps to start running clamav as a dokku plugin

### Related PRs
https://github.com/backstitch/backstitch/pull/1972
https://github.com/backstitch/studio/pull/449

### Tested Scenarios
Tested this with running on reader and studio in the sandbox
Steps:
1. SSH into either the studio or reader sandbox servers
2. `sudo dokku plugin:uninstall clamav` to delete the already existing clamav plugin
3. `sudo dokku plugin:install https://github.com/backstitch/dokku-clamav.git --committish STUDIO-52_update_clamav_plugin clamav` to re-install the plugin
4. `sudo dokku ps:rebuild studio` to restart the sandbox and make sure the plugin installs correctly
5. `sudo docker exec -it <container_name> /bin/bash` to bash into the docker container and then run `clamd &` to start the daemon. Use `sudo docker ps` to find the name of the container depending on studio or reader

Still need to setup running the antivirus updater and daemon on the docker container to start automatically but that is not part of this repo
